### PR TITLE
examples: Add testing many browsers from browserstack (received with api)

### DIFF
--- a/browserstack/src/main/kotlin/browserstack.kt
+++ b/browserstack/src/main/kotlin/browserstack.kt
@@ -16,7 +16,10 @@ object BrowserstackSessionCreator : SessionFactory<BSSession> {
 }
 
 class BSSession(sessionId: String, webDriver: WebDriver) : Session(sessionId, webDriver) {
-    val api: BrowserStackApi = BrowserStackApi.create(webDriver.executor)
+    val api: BrowserStackApi by lazy { BrowserStackApi.create(webDriver.executor) }
+    override suspend fun close() {
+        kotlin.runCatching {  super.close() } // simple ignore this!
+    }
 }
 
 fun browserstack(
@@ -27,6 +30,9 @@ fun browserstack(
 ): WebDriver =
     webdriver(baseUrl,
         errorConverters = errorConverters,
+        jsonConfig = {
+            ignoreUnknownKeys = true
+        },
         httpConfig = {
             install(Auth) {
                 basic {

--- a/core/src/main/kotlin/me/darkweird/sekt/core/common.kt
+++ b/core/src/main/kotlin/me/darkweird/sekt/core/common.kt
@@ -11,14 +11,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.encodeToJsonElement
-import kotlin.collections.List
-import kotlin.collections.MutableMap
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.forEach
-import kotlin.collections.listOf
-import kotlin.collections.map
-import kotlin.collections.mutableMapOf
 import kotlin.collections.set
 import kotlin.reflect.KProperty
 
@@ -47,6 +39,8 @@ interface SessionFactory<R> {
 }
 
 class WebDriverConfig(
+    val converters: List<ErrorConverter> = listOf(),
+    val json: Json? = null,
     val executorFactory: () -> HttpClient
 )
 
@@ -54,7 +48,17 @@ open class WebDriver(
     val baseUrl: String,
     configFactory: () -> WebDriverConfig
 ) {
-    val executor: HttpClient = configFactory().executorFactory()
+    val executor: HttpClient
+    val errorConverters: List<ErrorConverter>
+    val json: Json
+    init {
+        configFactory().let {
+            executor = it.executorFactory()
+            errorConverters = it.converters.reversed() + defaultConverter()
+            json = it.json ?: Json
+        }
+    }
+
 }
 
 open class Session(

--- a/core/src/main/kotlin/me/darkweird/sekt/core/exceptions.kt
+++ b/core/src/main/kotlin/me/darkweird/sekt/core/exceptions.kt
@@ -3,7 +3,7 @@ package me.darkweird.sekt.core
 import kotlinx.serialization.json.JsonElement
 
 
-public class WebDriverException(
+class WebDriverException(
     message: String,
     val kind: ErrorKind,
     val stacktrace: String? = null,
@@ -27,7 +27,7 @@ fun defaultConverter(): ErrorConverter = { code, body ->
         )
     } else {
         WebDriverException(
-            "received json error without 'value' property",
+            "This response - non-W3C response, cannot deserialize as Success nor Error",
             UnknownErrorKind(code, "unknown"),
             stacktrace = ""
         )

--- a/core/src/main/kotlin/me/darkweird/sekt/core/ktor.kt
+++ b/core/src/main/kotlin/me/darkweird/sekt/core/ktor.kt
@@ -1,14 +1,14 @@
 package me.darkweird.sekt.core
 
 import io.ktor.client.call.*
-import io.ktor.client.call.body
-import io.ktor.client.call.body
-import io.ktor.client.call.body
-import io.ktor.client.call.body
-import io.ktor.client.call.body
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
 
 
 @Serializable
@@ -19,32 +19,24 @@ data class WebDriverResponse<T>(
 @Serializable
 object Empty
 
+
 suspend inline fun <reified R> WebDriver.get(path: String): R {
-    return executor.get(baseUrl + path).body<WebDriverResponse<R>>().value
+    return executor.get(baseUrl + path).decodeWebDriver(json, errorConverters)
 }
 
-suspend inline fun <reified T : Any, reified R> WebDriver.post(path: String, body: T): R =
-    if (R::class == Unit::class) {
-        executor.post(baseUrl + path) {
-            setBody(body)
-            contentType(ContentType.Application.Json)
-        }.body<WebDriverResponse<R>>().value
-        Unit as R
-    } else {
-        executor.post(baseUrl + path) {
-            setBody(body)
-            contentType(ContentType.Application.Json)
-        }.body<WebDriverResponse<R>>().value
+suspend inline fun <reified T : Any, reified R> WebDriver.post(path: String, body: T): R {
+    val resp = executor.post(baseUrl + path) {
+        setBody(body)
+        contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
     }
+    return decodeNullable(resp, json, errorConverters)
+}
 
 
-suspend inline fun <reified R> WebDriver.delete(path: String): R =
-    if (R::class == Unit::class) {
-        executor.delete(baseUrl + path).body<WebDriverResponse<Empty?>>().value
-        Unit as R
-    } else {
-        executor.delete(baseUrl + path).body<WebDriverResponse<R>>().value
-    }
+suspend inline fun <reified R> WebDriver.delete(path: String): R {
+    val resp = executor.delete(baseUrl + path)
+    return decodeNullable(resp, json, errorConverters)
+}
 
 suspend inline fun <reified R> Session.get(path: String): R =
     webDriver.get("/session/$sessionId$path")
@@ -65,7 +57,28 @@ suspend inline fun <reified R> WebElement.delete(path: String): R =
 suspend inline fun <reified T : Any, reified R> WebElement.post(path: String, body: T): R =
     session.post("/element/$elementId$path", body)
 
+suspend inline fun <reified R> HttpResponse.decodeWebDriver(
+    deserializer: Json,
+    errorConverters: List<ErrorConverter>
+): R {
+    val json = body<JsonElement>()
+    try {
+        return deserializer.decodeFromJsonElement<WebDriverResponse<R>>(json).value
+    } catch (e: SerializationException) {
+        throw errorConverters
+            .firstNotNullOf { it(this.status.value, json) }
+    }
+}
 
-
-
-
+suspend inline fun <reified R> decodeNullable(
+    resp: HttpResponse,
+    deserializer: Json,
+    converters: List<ErrorConverter>
+): R {
+    return if (R::class == Unit::class) {
+        resp.decodeWebDriver<Empty?>(deserializer, converters)
+        Unit as R
+    } else {
+        resp.decodeWebDriver(deserializer, converters)
+    }
+}

--- a/examples/common/src/main/kotlin/me/darkweird/example/theinternettests.kt
+++ b/examples/common/src/main/kotlin/me/darkweird/example/theinternettests.kt
@@ -8,7 +8,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
-import me.darkweird.sekt.core.*
+import me.darkweird.sekt.core.Empty
+import me.darkweird.sekt.core.Session
+import me.darkweird.sekt.core.WebDriverException
+import me.darkweird.sekt.core.waitUntil
 import me.darkweird.sekt.w3c.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime

--- a/examples/the-internet-browserstack/build.gradle.kts
+++ b/examples/the-internet-browserstack/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     testImplementation(project(":examples:common"))
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
+    testImplementation("io.kotest:kotest-framework-datatest:5.4.2")
     testImplementation("ch.qos.logback:logback-classic:1.2.10")
     testImplementation("io.ktor:ktor-client-cio-jvm:$ktor_version")
     testImplementation("io.ktor:ktor-client-logging-jvm:$ktor_version")

--- a/examples/the-internet-browserstack/src/test/kotlin/me/darkweird/example/TheInternetTests.kt
+++ b/examples/the-internet-browserstack/src/test/kotlin/me/darkweird/example/TheInternetTests.kt
@@ -1,9 +1,15 @@
 package me.darkweird.example
 
 import io.kotest.common.ExperimentalKotest
+import io.kotest.common.runBlocking
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.string.shouldContain
 import io.kotest.mpp.env
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.logging.*
+import me.darkweird.browserstack.Browser
+import me.darkweird.browserstack.BrowserStackApi
 import me.darkweird.browserstack.Status
 import me.darkweird.browserstack.StatusRequest
 import me.darkweird.sekt.browserstack.BSSession
@@ -11,12 +17,12 @@ import me.darkweird.sekt.browserstack.BrowserStackCapabilities.browserStack
 import me.darkweird.sekt.browserstack.BrowserstackSessionCreator
 import me.darkweird.sekt.browserstack.browserStack
 import me.darkweird.sekt.browserstack.browserstack
-import me.darkweird.sekt.core.*
+import me.darkweird.sekt.core.capabilities
+import me.darkweird.sekt.core.session
 import me.darkweird.sekt.w3c.*
 import me.darkweird.sekt.w3c.W3CCapabilities.browserName
 import me.darkweird.sekt.w3c.W3CCapabilities.browserVersion
 import me.darkweird.sekt.w3c.W3CCapabilities.platformName
-import kotlin.time.ExperimentalTime
 
 private val time = java.time.LocalDateTime.now()
 
@@ -35,9 +41,6 @@ private suspend fun withTestSession(
         username = env("BS_USERNAME") ?: throw IllegalArgumentException("env variable BS_USERNAME should be provided"),
         password = env("BS_PASSWORD") ?: throw IllegalArgumentException("env variable BS_PASSWORD should be provided")
     )
-    val choosedBrowser =
-        browserstack
-
     browserstack.session(
         BrowserstackSessionCreator,
         capabilities
@@ -64,10 +67,94 @@ private suspend fun withTestSession(
 
 
 @OptIn(ExperimentalKotest::class)
-@ExperimentalTime
 class TheInternetTests : FunSpec() {
     init {
         concurrency = 4
         theInternetTests(::withTestSession)
+    }
+}
+
+
+@OptIn(ExperimentalKotest::class)
+class RunAtAllBrowserTests : FunSpec() {
+    init {
+
+        val browserstack = browserstack(
+            "https://hub-cloud.browserstack.com/wd/hub",
+            errorConverters = listOf(w3cConverter()),
+            httpConfig = {
+                install(Logging) {
+                    level = LogLevel.ALL
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 60_000
+                }
+            },
+            username = env("BS_USERNAME")
+                ?: throw IllegalArgumentException("env variable BS_USERNAME should be provided"),
+            password = env("BS_PASSWORD")
+                ?: throw IllegalArgumentException("env variable BS_PASSWORD should be provided")
+        )
+
+        val api = BrowserStackApi.create(browserstack.executor)
+
+        //Setup concurrency as your plan can
+        dispatcherAffinity = true
+        concurrency = runBlocking { api.getPlanDetails() }.parallelSessionsMaxAllowed
+
+        val browsers = runBlocking { api.getBrowsers() }
+            .filter {
+                if (it.realMobile != null) { // Filter out mobiles, we haven't appium's capabilities (device name)
+                    false
+                } else if (it.os == "OS X") { // Filter out Mac - browserstack provides non-selenium parameters
+                    false
+                } else {
+                    when (it.browser) { // Filter out outdated webdrivers
+                        "firefox" -> (it.browserVersion?.substringBefore(".")?.toInt() ?: 0) > 58
+                        "chrome" -> (it.browserVersion?.substringBefore(".")?.toInt() ?: 0) > 90
+                        "edge" -> (it.browserVersion?.substringBefore(".")?.toInt() ?: 0) > 17
+                        "opera" -> false
+                        "ie" -> false
+                        else -> true
+                    }
+                }
+            }
+
+        withData(
+            { "${it.os} ${it.osVersion} - ${it.browser} - ${it.browserVersion}" },
+            browsers
+        ) { browser: Browser ->
+            browserstack.session(
+                BrowserstackSessionCreator,
+                capabilities {
+                    platformName = browser.os
+                    browserName = browser.browser
+                    browser.browserVersion?.let {
+                        browserVersion = it
+                    }
+                    browserStack = browserStack {
+                        projectName = "Sekt"
+                        buildName = "All Browsers test - $time"
+                    }
+                }
+            ) {
+                runCatching {
+                    setUrl(PageUrl("http://the-internet.herokuapp.com/login"))
+
+                    findElement(css("#username")).sendKeys(Text("tomsmith"))
+                    findElement(css("#password")).sendKeys(Text("SuperSecretPassword!"))
+                    findElement(css("#login button")).click()
+
+                    findElement(css("#flash")).getText() shouldContain "You logged into a secure area!"
+                }.onSuccess {
+                    api.session.setTestStatus(sessionId, StatusRequest(Status.PASSED, "Test passed!"))
+                }.onFailure {
+                    api.session.setTestStatus(
+                        sessionId,
+                        StatusRequest(Status.FAILED, it.message ?: "Unknown error")
+                    )
+                }.getOrThrow()
+            }
+        }
     }
 }

--- a/examples/the-internet-w3c-ktor/src/test/kotlin/me/darkweird/example/TheInternetTests.kt
+++ b/examples/the-internet-w3c-ktor/src/test/kotlin/me/darkweird/example/TheInternetTests.kt
@@ -3,10 +3,13 @@ package me.darkweird.example
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
 import io.ktor.client.engine.cio.*
-import me.darkweird.sekt.core.*
-import me.darkweird.sekt.w3c.*
+import me.darkweird.sekt.core.Session
+import me.darkweird.sekt.core.capabilities
+import me.darkweird.sekt.core.webdriver
 import me.darkweird.sekt.w3c.W3CCapabilities.browserName
 import me.darkweird.sekt.w3c.W3CCapabilities.platformName
+import me.darkweird.sekt.w3c.session
+import me.darkweird.sekt.w3c.w3cConverter
 import kotlin.time.ExperimentalTime
 
 
@@ -32,7 +35,7 @@ private suspend fun withTestSession(block: suspend Session.() -> Unit) {
 @ExperimentalTime
 class TheInternetTests : FunSpec() {
     init {
-        concurrency = 1
+        concurrency = 5
         theInternetTests { _, s ->
             withTestSession(s)
         }

--- a/w3c/src/main/kotlin/me/darkweird/sekt/w3c/model.kt
+++ b/w3c/src/main/kotlin/me/darkweird/sekt/w3c/model.kt
@@ -1,6 +1,9 @@
 package me.darkweird.sekt.w3c
 
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.mapSerialDescriptor
 import kotlinx.serialization.descriptors.serialDescriptor


### PR DESCRIPTION
* Move error handling from Ktor handlers to get/post/delete wrappers